### PR TITLE
Ghunt Module Dependency Error

### DIFF
--- a/modules/ghunt/requirements.txt
+++ b/modules/ghunt/requirements.txt
@@ -1,2 +1,2 @@
-ghunt==2.0.3
+ghunt==2.0.4
 geocoder==1.38.1


### PR DESCRIPTION
Updates python package ghunt in modules/ghunt/requirements.txt to version 2.0.4 to resolve issue #8 "Dependency Key Error."